### PR TITLE
[FIX][IMP] account_bank_statement_import_online_paypal: empty pulls, name format

### DIFF
--- a/account_bank_statement_import_online/__manifest__.py
+++ b/account_bank_statement_import_online/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Online Bank Statements',
-    'version': '11.0.1.1.2',
+    'version': '11.0.1.2.0',
     'author':
         'CorporateHub, '
         'Odoo Community Association (OCA)',

--- a/account_bank_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_bank_statement_import_online/models/online_bank_statement_provider.py
@@ -229,11 +229,7 @@ class OnlineBankStatementProvider(models.Model):
                 ], limit=1)
                 if not statement:
                     statement_values.update({
-                        'name': provider.journal_id.sequence_id.with_context(
-                            ir_sequence_date=fields.Date.to_string(
-                                statement_date
-                            ),
-                        ).next_by_id(),
+                        'name': provider._get_statement_name(statement_date),
                         'journal_id': provider.journal_id.id,
                         'date': fields.Date.to_string(statement_date),
                     })
@@ -384,6 +380,14 @@ class OnlineBankStatementProvider(models.Model):
         tz = timezone(self.tz) if self.tz else utc
         date_since = date_since.replace(tzinfo=utc).astimezone(tz)
         return date_since.date()
+
+    @api.multi
+    def _get_statement_name(self, statement_date):
+        """Hook for extension. Default behaviour: use the journal's sequence."""
+        self.ensure_one()
+        return self.journal_id.sequence_id.with_context(
+            ir_sequence_date=fields.Date.to_string(statement_date),
+        ).next_by_id()
 
     @api.multi
     def _generate_unique_import_id(self, unique_import_id):

--- a/account_bank_statement_import_online_paypal/__manifest__.py
+++ b/account_bank_statement_import_online_paypal/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Online Bank Statements: PayPal.com',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'author':
         'CorporateHub, '
         'Odoo Community Association (OCA)',

--- a/account_bank_statement_import_online_paypal/__manifest__.py
+++ b/account_bank_statement_import_online_paypal/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Online Bank Statements: PayPal.com',
-    'version': '11.0.1.0.1',
+    'version': '11.0.1.1.0',
     'author':
         'CorporateHub, '
         'Odoo Community Association (OCA)',

--- a/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
+++ b/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
@@ -415,7 +415,7 @@ class OnlineBankStatementProviderPayPal(models.Model):
                 transaction_date,
         )
         data = self._paypal_retrieve(url, token)
-        transactions = data['transaction_details']
+        transactions = data.get('transaction_details', [])
         for transaction in transactions:
             if transaction['transaction_info']['transaction_id'] != \
                     transaction_id:
@@ -468,7 +468,7 @@ class OnlineBankStatementProviderPayPal(models.Model):
                     lambda transaction: self._paypal_preparse_transaction(
                         transaction
                     ),
-                    data['transaction_details']
+                    data.get('transaction_details', [])
                 )
                 transactions += list(filter(
                     lambda transaction:
@@ -477,7 +477,7 @@ class OnlineBankStatementProviderPayPal(models.Model):
                         ) < interval_end,
                     interval_transactions
                 ))
-                total_pages = data['total_pages']
+                total_pages = data.get('total_pages', 0)
                 page += 1
             interval_start += interval_step
         return transactions

--- a/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
+++ b/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
@@ -472,7 +472,8 @@ class OnlineBankStatementProviderPayPal(models.Model):
                 )
                 transactions += list(filter(
                     lambda transaction:
-                        interval_start <= self._paypal_get_transaction_date(
+                        transaction is not None
+                        and interval_start <= self._paypal_get_transaction_date(
                             transaction
                         ) < interval_end,
                     interval_transactions


### PR DESCRIPTION
  Summary

  - [FIX] account_bank_statement_import_online_paypal: tolerate 200 OK responses that omit transaction_details (and sometimes total_pages) when a currency/range has no movements.
  - [IMP] account_bank_statement_import_online: extract a _get_statement_name(statement_date) hook on the base provider so downstream modules can customize the statement name without rewriting _pull. Default
  behaviour (journal sequence) is unchanged.
  - [IMP] account_bank_statement_import_online_paypal: drop None entries from the transaction filter in _paypal_get_transactions, so downstream modules can override _paypal_preparse_transaction to discard a
  transaction by returning None.

All three changes are backwards-compatible: default behaviour is identical to before.

